### PR TITLE
Fd 1734 handling uppercase enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Traceback (most recent call last):
 protobuf_to_dict.convertor.FieldsMissing: Missing fields: transacted_at, status
 ````
 
-##Caveats
+## Caveats
 
 This library grew out of the desire to serialize a protobuf-encoded message to
 [JSON](http://json.org/). As JSON has no built-in binary type (all strings in
@@ -137,6 +137,15 @@ string labels instead, pass `use_enum_labels=True` into `protobuf_to_dict`:
 ```python
 >>> protobuf_to_dict(my_message, use_enum_labels=True)
 ```
+
+And if you need the enum labels to be automatically converted to lowercase:
+
+```py
+>>> protobuf_to_dict(my_message, use_enum_labels=True, lowercase_enum_lables=True)
+```
+
+When you convert from dictionary to protobuf, if you need the enums to work both
+in lowercase and uppercase, set the `strict=False`.
 
 # Testing
 

--- a/protobuf_to_dict/convertor.py
+++ b/protobuf_to_dict/convertor.py
@@ -17,6 +17,7 @@ def datetime_to_timestamp(dt):
     ts.FromDatetime(dt)
     return ts
 
+
 def timestamp_to_datetime(ts):
     dt = ts.ToDatetime()
     return dt
@@ -49,8 +50,10 @@ def repeated(type_callable):
     return lambda value_list: [type_callable(value) for value in value_list]
 
 
-def enum_label_name(field, value):
-    return field.enum_type.values_by_number[int(value)].name
+def enum_label_name(field, value, lowercase_enum_lables=False):
+    label = field.enum_type.values_by_number[int(value)].name
+    label = label.lower() if lowercase_enum_lables else label
+    return label
 
 
 def _is_map_entry(field):
@@ -60,7 +63,7 @@ def _is_map_entry(field):
 
 
 def protobuf_to_dict(pb, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=False,
-                     including_default_value_fields=False):
+                     including_default_value_fields=False, lowercase_enum_lables=False):
     result_dict = {}
     extensions = {}
     for field, value in pb.ListFields():
@@ -69,12 +72,14 @@ def protobuf_to_dict(pb, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=Fa
             value_field = field.message_type.fields_by_name['value']
             type_callable = _get_field_value_adaptor(
                 pb, value_field, type_callable_map,
-                use_enum_labels, including_default_value_fields)
+                use_enum_labels, including_default_value_fields,
+                lowercase_enum_lables)
             for k, v in value.items():
                 result_dict[field.name][k] = type_callable(v)
             continue
         type_callable = _get_field_value_adaptor(pb, field, type_callable_map,
-                                                 use_enum_labels, including_default_value_fields)
+                                                 use_enum_labels, including_default_value_fields,
+                                                 lowercase_enum_lables)
         if field.label == FieldDescriptor.LABEL_REPEATED:
             type_callable = repeated(type_callable)
 
@@ -107,7 +112,7 @@ def protobuf_to_dict(pb, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=Fa
 
 
 def _get_field_value_adaptor(pb, field, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=False,
-                             including_default_value_fields=False):
+                             including_default_value_fields=False, lowercase_enum_lables=False):
 
     if field.message_type and field.message_type.name == Timestamp_type_name:
         return timestamp_to_datetime
@@ -117,10 +122,11 @@ def _get_field_value_adaptor(pb, field, type_callable_map=TYPE_CALLABLE_MAP, use
             pb, type_callable_map=type_callable_map,
             use_enum_labels=use_enum_labels,
             including_default_value_fields=including_default_value_fields,
+            lowercase_enum_lables=lowercase_enum_lables,
         )
 
     if use_enum_labels and field.type == FieldDescriptor.TYPE_ENUM:
-        return lambda value: enum_label_name(field, value)
+        return lambda value: enum_label_name(field, value, lowercase_enum_lables)
 
     if field.type in type_callable_map:
         return type_callable_map[field.type]
@@ -133,7 +139,8 @@ REVERSE_TYPE_CALLABLE_MAP = {
 }
 
 
-def dict_to_protobuf(pb_klass_or_instance, values, type_callable_map=REVERSE_TYPE_CALLABLE_MAP, strict=True, ignore_none=False):
+def dict_to_protobuf(pb_klass_or_instance, values, type_callable_map=REVERSE_TYPE_CALLABLE_MAP,
+                     strict=True, ignore_none=False):
     """Populates a protobuf model from a dictionary.
 
     :param pb_klass_or_instance: a protobuf message class, or an protobuf instance
@@ -144,6 +151,7 @@ def dict_to_protobuf(pb_klass_or_instance, values, type_callable_map=REVERSE_TYP
        values on the target instance.
     :param bool strict: complain if keys in the map are not fields on the message.
     :param bool strict: ignore None-values of fields, treat them as empty field
+    :param bool strict: when false: accept enums both in lowercase and uppercase
     """
     if isinstance(pb_klass_or_instance, Message):
         instance = pb_klass_or_instance
@@ -200,7 +208,7 @@ def _dict_to_protobuf(pb, value, type_callable_map, strict, ignore_none):
                     m = pb_value.add()
                     _dict_to_protobuf(m, item, type_callable_map, strict, ignore_none)
                 elif field.type == FieldDescriptor.TYPE_ENUM and isinstance(item, six.string_types):
-                    pb_value.append(_string_to_enum(field, item))
+                    pb_value.append(_string_to_enum(field, item, strict))
                 else:
                     pb_value.append(item)
             continue
@@ -222,21 +230,22 @@ def _dict_to_protobuf(pb, value, type_callable_map, strict, ignore_none):
             continue
 
         if field.type == FieldDescriptor.TYPE_ENUM and isinstance(input_value, six.string_types):
-            input_value = _string_to_enum(field, input_value)
+            input_value = _string_to_enum(field, input_value, strict)
 
         setattr(pb, field.name, input_value)
 
     return pb
 
 
-def _string_to_enum(field, input_value):
-    enum_dict = field.enum_type.values_by_name
+def _string_to_enum(field, input_value, strict=False):
     try:
-        input_value = enum_dict[input_value].number
+        input_value = field.enum_type.values_by_name[input_value].number
     except KeyError:
-        raise KeyError("`%s` is not a valid value for field `%s`" % (input_value, field.name))
+        if strict:
+            raise KeyError("`%s` is not a valid value for field `%s`" % (input_value, field.name))
+        else:
+            return _string_to_enum(field, input_value.upper(), strict=True)
     return input_value
-
 
 
 def get_field_names_and_options(pb):

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,14 @@ setup(
                  'protocol buffers and the reverse. Useful as an intermediate '
                  'step before serialisation (e.g. to JSON). '
                  'Kapor: upgrade it to PB3 and PY3, rename it to protobuf3-to-dict'),
-    version='0.2.2',
+    version='0.2.3',
     author='Kapor Zhu',
     author_email='kapor.zhu@gmail.com',
     url='https://github.com/kaporzhu/protobuf-to-dict',
     license='Public Domain',
     keywords=['protobuf', 'json', 'dict'],
     install_requires=reqs,
-    packages = ['protobuf_to_dict'],
+    packages=['protobuf_to_dict'],
     tests_require=['pytest'],
     test_suite='nose.collector',
     classifiers=[

--- a/tests/test_proto_to_dict.py
+++ b/tests/test_proto_to_dict.py
@@ -43,6 +43,22 @@ class TestProtoConvertor:
         with pytest.raises(KeyError):
             dict_to_protobuf(MessageOfTypes, d)
 
+    def test_lowercase_enum_lables_work(self):
+        m = self.populate_MessageOfTypes()
+        d = protobuf_to_dict(m, use_enum_labels=True, lowercase_enum_lables=True)
+        self.compare(m, d, ['enm', 'enmRepeated', 'nestedRepeated', 'nestedMap'])
+        assert d['enm'] == 'c'
+        assert d['enmRepeated'] == ['a', 'c']
+
+        d['enm'] = 'meow'
+        d['enm'] = 'a'
+        d['enmRepeated'] = ['a', 'c']
+
+        with pytest.raises(KeyError):
+            dict_to_protobuf(MessageOfTypes, d)
+
+        dict_to_protobuf(MessageOfTypes, d, strict=False)
+
     def test_repeated_enum(self):
         m = self.populate_MessageOfTypes()
         d = protobuf_to_dict(m, use_enum_labels=True)


### PR DESCRIPTION
FD-1734 Accept enums both in lowercase and uppercase when not strict.

Background: SQLAlchemy relations are defined in lowercase but Protobuf enums are supposed to be uppercase. This PR makes the protobuf-to-dict flexible to deal with uppercase vs lowercase enum conversion to the protobuf number.