### PR TITLE
use empty array for defualts on repeatables

### DIFF
--- a/protobuf_to_dict/convertor.py
+++ b/protobuf_to_dict/convertor.py
@@ -103,6 +103,8 @@ def protobuf_to_dict(pb, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=Fa
                 continue
             if _is_map_entry(field):
                 result_dict[field.name] = {}
+            elif field.label == FieldDescriptor.LABEL_REPEATED:
+                result_dict[field.name] = []
             else:
                 result_dict[field.name] = field.default_value
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
                  'protocol buffers and the reverse. Useful as an intermediate '
                  'step before serialisation (e.g. to JSON). '
                  'Kapor: upgrade it to PB3 and PY3, rename it to protobuf3-to-dict'),
-    version='0.2.3',
+    version='0.2.4',
     author='Kapor Zhu',
     author_email='kapor.zhu@gmail.com',
     url='https://github.com/kaporzhu/protobuf-to-dict',


### PR DESCRIPTION
For repeated fields of Messages, there is no `default_value` property. This just sets any repeatable field's default to an empty list.