### PR TITLE
Add default enum strings from proto to dict

### DIFF
--- a/protobuf_to_dict/convertor.py
+++ b/protobuf_to_dict/convertor.py
@@ -105,6 +105,8 @@ def protobuf_to_dict(pb, type_callable_map=TYPE_CALLABLE_MAP, use_enum_labels=Fa
                 result_dict[field.name] = {}
             elif field.label == FieldDescriptor.LABEL_REPEATED:
                 result_dict[field.name] = []
+            elif field.type == FieldDescriptor.TYPE_ENUM and use_enum_labels:
+                result_dict[field.name] = enum_label_name(field, field.default_value, lowercase_enum_lables)
             else:
                 result_dict[field.name] = field.default_value
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
                  'protocol buffers and the reverse. Useful as an intermediate '
                  'step before serialisation (e.g. to JSON). '
                  'Kapor: upgrade it to PB3 and PY3, rename it to protobuf3-to-dict'),
-    version='0.2.4',
+    version='0.2.5',
     author='Kapor Zhu',
     author_email='kapor.zhu@gmail.com',
     url='https://github.com/kaporzhu/protobuf-to-dict',


### PR DESCRIPTION
Currently, when converting from proto to dict on an enum, and use_enum_labels is True, it will return a string label for everything except the default (0). Default will still return an integer 0. 

This fixes it so default enums will return their proper label when use_enum_labels is True.