### PR TITLE
datetime fix for fetched_by in request

### DIFF
--- a/protobuf_to_dict/convertor.py
+++ b/protobuf_to_dict/convertor.py
@@ -1,6 +1,7 @@
 # -*- coding:utf-8 -*-
 import six
 import datetime
+from dateutil.parser import parse as date_parser
 
 from google.protobuf.message import Message
 from google.protobuf.descriptor import FieldDescriptor

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
                  'protocol buffers and the reverse. Useful as an intermediate '
                  'step before serialisation (e.g. to JSON). '
                  'Kapor: upgrade it to PB3 and PY3, rename it to protobuf3-to-dict'),
-    version='0.2.7',
+    version='0.2.8',
     author='Kapor Zhu',
     author_email='kapor.zhu@gmail.com',
     url='https://github.com/kaporzhu/protobuf-to-dict',

--- a/tests/test_proto_to_dict.py
+++ b/tests/test_proto_to_dict.py
@@ -235,6 +235,17 @@ class TestDateTime:
         obj1_again = dict_to_protobuf(sample_pb2.Obj, values=pb_dict)
         assert obj1 == obj1_again
 
+    def test_dict_to_protobuf_with_param_use_date_parser_for_fields(self):
+        dt = datetime.datetime.utcnow() - datetime.timedelta(days=365)
+        dt_iso_str = dt.isoformat()
+        ts = datetime_to_timestamp(dt)
+
+        obj = sample_pb2.Obj(item_id="item id", transacted_at=ts, status=sample_pb2.Status.OK)
+        dict_obj = {"item_id": "item id", "transacted_at": dt_iso_str, "status": 0}
+        
+        obj_again = dict_to_protobuf(sample_pb2.Obj, values=dict_obj, use_date_parser_for_fields=["transacted_at"])
+        assert obj == obj_again
+
 
 class TestOptions:
 


### PR DESCRIPTION
## Description
This PR is fixing the issue in `dynamo_persister` of `provide_n_persist`. When persisting the data, the `request_str` is using `isoformat()` to dump json DateTime data in order to store the raw request in DynamoDB. This causes the error when `implement_lookup_endpoint` try to convert the raw request back to the original request proto. 

### Jira Ticket(s)
https://faircorp.atlassian.net/browse/IN-644