### PR TITLE
Better field mapping error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# IDE
+.idea

--- a/protobuf_to_dict/convertor.py
+++ b/protobuf_to_dict/convertor.py
@@ -47,6 +47,16 @@ TYPE_CALLABLE_MAP = {
 }
 
 
+class InvalidFieldFoundException(Exception):
+    def __init__(self, variable_name, value, error_message):
+        self.variable_name = variable_name
+        self.value = value
+        self.error_message = error_message
+        klass = value.__class__.__name__
+        message = f"variable `{variable_name}` has type `{klass}` with value `{value}` and had an error: {error_message}"
+        super().__init__(message)
+
+
 def repeated(type_callable):
     return lambda value_list: [type_callable(value) for value in value_list]
 
@@ -168,6 +178,9 @@ def dict_to_protobuf(pb_klass_or_instance, values, type_callable_map=REVERSE_TYP
 
 def _get_field_mapping(pb, dict_value, strict):
     field_mapping = []
+    if not hasattr(dict_value, "items"):
+        raise InvalidFieldFoundException("dict_value", dict_value, "does not have an attribute items")
+
     for key, value in dict_value.items():
         if key == EXTENSION_CONTAINER:
             continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 protobuf>=2.3.0
 six
+python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
                  'protocol buffers and the reverse. Useful as an intermediate '
                  'step before serialisation (e.g. to JSON). '
                  'Kapor: upgrade it to PB3 and PY3, rename it to protobuf3-to-dict'),
-    version='0.2.8',
+    version='0.2.9',
     author='Kapor Zhu',
     author_email='kapor.zhu@gmail.com',
     url='https://github.com/kaporzhu/protobuf-to-dict',

--- a/tests/test_proto_to_dict.py
+++ b/tests/test_proto_to_dict.py
@@ -4,6 +4,7 @@ import pytest
 
 from google.protobuf.descriptor import FieldDescriptor
 
+from protobuf_to_dict.convertor import InvalidFieldFoundException
 from tests import sample_pb2
 from tests.sample_pb2 import MessageOfTypes
 from protobuf_to_dict import (
@@ -22,6 +23,14 @@ class TestProtoConvertor:
 
         m2 = dict_to_protobuf(MessageOfTypes, d)
         assert m == m2
+
+        d = 'CAT'
+        with pytest.raises(InvalidFieldFoundException) as error:
+            dict_to_protobuf(MessageOfTypes, d)
+
+        expected_error = "does not have an attribute items"
+        expected_message = f"variable `dict_value` has type `str` with value `CAT` and had an error: {expected_error}"
+        assert str(error.value) == expected_message
 
     def test_use_enum_labels(self):
         m = self.populate_MessageOfTypes()


### PR DESCRIPTION
Creating better error messaging for debugging purposes.

Example:
```
protobuf_to_dict.convertor.InvalidFieldFoundException: variable `dict_value` has type `str` with value Fair and had an error: does not have an attribute items
```

Needed to add python-dateutils to requirements.txt, because tests wouldn't run in 3.8.7 without it.